### PR TITLE
[fix] Item_MagnetEffect.cs [feat] TY_Debug.cs

### DIFF
--- a/Yandere/Assets/00.Scenes/GameScene.unity
+++ b/Yandere/Assets/00.Scenes/GameScene.unity
@@ -1074,6 +1074,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ba9182676aee9e4d90e858d558dcf55, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  normalEnemyPrefab: {fileID: 1439856908508736086, guid: 426c24634e7bb0744a023822e5f27f2a, type: 3}
+  eliteEnemyPrefab: {fileID: 1439856908508736086, guid: d91ea8ff02e7b2744bf35232a1b35654, type: 3}
+  bossEnemyPrefab: {fileID: 1439856908508736086, guid: 58d0570b78bc20f459caa017bcd9b537, type: 3}
+  itemObjectPrefab: {fileID: 8906970490064105965, guid: e7fc76a3b76053947a1a2daa49bfa77f, type: 3}
 --- !u!4 &1248482716
 Transform:
   m_ObjectHideFlags: 0

--- a/Yandere/Assets/01.Scripts/Debug/TY_Debug.cs
+++ b/Yandere/Assets/01.Scripts/Debug/TY_Debug.cs
@@ -1,8 +1,18 @@
 using NaughtyAttributes;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 
 public class TY_Debug : MonoBehaviour
 {
+    [Foldout("📦 프리팹 디버그용")]
+    public GameObject normalEnemyPrefab;
+    [Foldout("📦 프리팹 디버그용")]
+    public GameObject eliteEnemyPrefab;
+    [Foldout("📦 프리팹 디버그용")]
+    public GameObject bossEnemyPrefab;
+    [Foldout("📦 프리팹 디버그용")]
+    public GameObject itemObjectPrefab;
+    
     [Button]
     public void DebugLevelUp()
     {
@@ -39,6 +49,51 @@ public class TY_Debug : MonoBehaviour
         StageManager.Instance.timeScale -= 1;
     }
 
+    [Button]
+    public void DebugSpawnNormalEnemy()
+    {
+        SpawnEnemy(normalEnemyPrefab);
+    }
 
+    [Button]
+    public void DebugSpawnEliteEnemy()
+    {
+        SpawnEnemy(eliteEnemyPrefab);
+    }
+    [Button]
+    public void DebugSpawnBossEnemy()
+    {
+        SpawnEnemy(bossEnemyPrefab);
+    }
 
+    [Button]
+    public void DebugSpawnObject()
+    {
+        SpawnItemObject(itemObjectPrefab);
+    }
+    
+    private void SpawnEnemy(GameObject enemyPrefab)
+    {
+        if (enemyPrefab == null)
+        {
+            Debug.LogWarning("Enemy prefab is not assigned.");
+            return;
+        }
+
+        Vector3 spawnPos = StageManager.Instance.Player.transform.position + new Vector3(Random.Range(-3f, 3f), Random.Range(-3f, 3f), 0);
+        Instantiate(enemyPrefab, spawnPos, Quaternion.identity);
+    }
+    
+    private void SpawnItemObject(GameObject itemObject)
+    {
+        if (itemObject == null)
+        {
+            Debug.LogWarning("Enemy prefab is not assigned.");
+            return;
+        }
+
+        Vector3 spawnPos = StageManager.Instance.Player.transform.position + new Vector3(Random.Range(-3f, 3f), Random.Range(-3f, 3f), 0);
+        Instantiate(itemObject, spawnPos, Quaternion.identity);
+    }
+    
 }

--- a/Yandere/Assets/01.Scripts/Item/Item_MagnetEffect.cs
+++ b/Yandere/Assets/01.Scripts/Item/Item_MagnetEffect.cs
@@ -8,7 +8,7 @@ public class Item_MagnetEffect : MonoBehaviour
 
     public void AttractAllItems()
     {
-        GameObject[] dropItems = GameObject.FindGameObjectsWithTag("Item");
+        GameObject[] dropItems = GameObject.FindGameObjectsWithTag("Item_ExpOrb");
 
         foreach (GameObject item in dropItems)
         {

--- a/Yandere/Assets/03.Prefabs/Prefabs_Item/Item_Large_Exp.prefab
+++ b/Yandere/Assets/03.Prefabs/Prefabs_Item/Item_Large_Exp.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: -4442597208217630260}
   m_Layer: 9
   m_Name: Item_Large_Exp
-  m_TagString: Item
+  m_TagString: Item_ExpOrb
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Yandere/Assets/03.Prefabs/Prefabs_Item/Item_Medium_Exp.prefab
+++ b/Yandere/Assets/03.Prefabs/Prefabs_Item/Item_Medium_Exp.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 2645157656514478043}
   m_Layer: 9
   m_Name: Item_Medium_Exp
-  m_TagString: Item
+  m_TagString: Item_ExpOrb
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Yandere/Assets/03.Prefabs/Prefabs_Item/Item_Small_Exp.prefab
+++ b/Yandere/Assets/03.Prefabs/Prefabs_Item/Item_Small_Exp.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 8827937946514640642}
   m_Layer: 9
   m_Name: Item_Small_Exp
-  m_TagString: Item
+  m_TagString: Item_ExpOrb
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Yandere/ProjectSettings/TagManager.asset
+++ b/Yandere/ProjectSettings/TagManager.asset
@@ -9,6 +9,7 @@ TagManager:
   - Enemy_Boss
   - PlayerSkill
   - Item
+  - Item_ExpOrb
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
[fix] Item_MagnetEffect.cs
자석 아이템을 획득 시 빨려오는 아이템을 경험치 오브(Item_ExpOrb)태그만 빨려 오게 끔 수정했습니다. -경험치구슬들을 Item_ExpOrb태그로 바꿔주면 그 아이템만 빨려옵니다.

[feat] TY_Debug.cs

에너미 버튼3개와 아이템오브젝트 버튼 1개를 추가 했습니다.

노말 / 엘리트 / 보스로 나누어서
소환하고 싶은 프리팹을 인스펙터 할당해주면 그 몬스터가 플레이어 근처로 소환 됩니다.(버튼 클릭시) Field_ItemObject 프리팹을  인스펙터에 할당 시켜주면 그 오브젝트가 플레이어 근처로 소환 됩니다.(버튼 클릭시)